### PR TITLE
Prepend test case name to kuttl test folders.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Generated kuttl tests prepend the original test name to the generated kuttl test folders ([#xxx])
+- Generated kuttl tests prepend the original test name to the generated kuttl test folders ([#1])
 
-[#xxx]: https://github.com/stackabletech/expand-tests/pull/xxx
+[#1]: https://github.com/stackabletech/expand-tests/pull/1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Changed
+
+- Generated kuttl tests prepend the original test name to the generated kuttl test folders ([#xxx])
+
+[#xxx]: https://github.com/stackabletech/expand-tests/pull/xxx
+

--- a/files/generate_tests.py
+++ b/files/generate_tests.py
@@ -7,6 +7,7 @@ import itertools
 import logging
 import sys
 import yaml
+from itertools import chain
 
 
 @dataclass
@@ -17,7 +18,10 @@ class TestCase:
 
     def __post_init__(self):
         self.name = "_".join(
-            "-".join([x, self.values.get(x)]) for x in self.values.keys()
+            chain(
+                [self.testcase],
+                ["-".join([x, self.values.get(x)]) for x in self.values.keys()],
+            )
         )
 
 


### PR DESCRIPTION
Prepend the test name to the generated kuttl test directories.

This enables us to run only one test, which would otherwise be indistinguishable from all other tests with the same dimensions.

Here is an example from the `spark-k8s-operator`. Before this PR:

```
$ tree tests/_work/tests/spark-pi-public-s3
tests/_work/tests/spark-pi-public-s3 
└── spark-3.2.1_hadoop-3.2.0_stackable-0.4.0   # <-- old name !!!
    ├── 00-assert.yaml
...
```

After this PR:

```
$ tree tests/_work/tests/spark-pi-public-s3
tests/_work/tests/spark-pi-public-s3
└── spark-pi-public-s3_spark-3.2.1_hadoop-3.2.0_stackable-0.4.0   # <-- new name !!!
    ├── 00-assert.yaml
...

```
